### PR TITLE
修正微信小程序支付模块bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ results, outTradeNo, err := wePay.AppPay(100))
 - [x] APP登录
 - [x] H5登录
 - [x] 小程序登录
-- [ ] 小程序支付
+- [x] 小程序支付
 - [ ] Web登录
 - [ ] 公众号支付
 - [ ] 扫码支付

--- a/README.md
+++ b/README.md
@@ -6,18 +6,22 @@
 
 
 ## 快速开始
-以下是APP支付简单例子
+以下是APP和小程序支付简单例子
 ```go
 wePay := &WePay{
 	AppId:     "xxx",
 	MchId:     "xxx",
 	PayKey:    "xxx",
 	NotifyUrl: "xxx",
-	TradeType: "xxx",
+	TradeType: "xxx", // APP支付填写`APP`,小程序支付填写`JSAPI`
 	Body:      "xxx",
 }
 
-results, outTradeNo, err := wePay.AppPay(100))
+# APP支付
+results, outTradeNo, err := wePay.AppPay(100) // 金额，以分为单位
+
+# 小程序支付
+results, outTradeNo, err := wePay.WaxPay(100, "open_id") // 金额，以分为单位；open_id为获取的用户的open_id
 ```
 
 ## 使用

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -35,7 +35,7 @@ type (
 		Sign      string `json:"sign,omitempty"`      // 签名
 	}
 
-	// AppRet 返回的基本内容
+	// WaxRet 返回的基本内容
 	WaxRet struct {
 		Timestamp string `json:"timeStamp,omitempty"` // 时间戳
 		NonceStr  string `json:"nonceStr,omitempty"`  // 随机字符串

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -18,15 +18,15 @@ type (
 		Body      string // 商品描述 必填
 	}
 
-	// Ret 返回的基本内容
-	Ret struct {
-		Timestamp string `json:"timeStamp,omitempty"` // 时间戳
-		NonceStr  string `json:"nonceStr,omitempty"`  // 随机字符串
+	// AppRet 返回的基本内容
+	AppRet struct {
+		Timestamp string `json:"timestamp,omitempty"` // 时间戳
+		NonceStr  string `json:"noncestr,omitempty"`  // 随机字符串
 	}
 
 	// AppPayRet 下单返回内容
 	AppPayRet struct {
-		Ret
+		AppRet
 
 		AppID     string `json:"appid,omitempty"`     // 应用ID
 		PartnerID string `json:"partnerid,omitempty"` // 微信支付分配的商户号
@@ -35,11 +35,17 @@ type (
 		Sign      string `json:"sign,omitempty"`      // 签名
 	}
 
+	// AppRet 返回的基本内容
+	WaxRet struct {
+		Timestamp string `json:"timeStamp,omitempty"` // 时间戳
+		NonceStr  string `json:"nonceStr,omitempty"`  // 随机字符串
+	}
+
 	// WaxPayRet 微信小程序下单返回内容
 	WaxPayRet struct {
-		Ret
+		WaxRet
 
-		AppID    string `json:"appId,omitempty"`
+		AppID    string `json:"appId,omitempty"`    // 应用ID
 		Package  string `json:"package,omitempty"`  // 扩展字段 统一下单接口返回的 prepay_id 参数值，提交格式如：prepay_id=*
 		SignType string `json:"signType,omitempty"` // 签名算法，暂支持 MD5
 		PaySign  string `json:"paySign,omitempty"`  // 签名
@@ -84,7 +90,7 @@ func (m *WePay) AppPay(totalFee int) (results *AppPayRet, outTradeNo string, err
 		return results, outTradeNo, err
 	}
 	results = &AppPayRet{
-		Ret: Ret{
+		AppRet: AppRet{
 			Timestamp: fmt.Sprintf("%d", time.Now().Unix()),
 			NonceStr:  unifiedOrderResp.NonceStr,
 		},
@@ -148,7 +154,7 @@ func (m *WePay) WaxPay(totalFee int, openID string) (results *WaxPayRet, outTrad
 		return results, outTradeNo, err
 	}
 	results = &WaxPayRet{
-		Ret: Ret{
+		WaxRet: WaxRet{
 			Timestamp: fmt.Sprintf("%d", time.Now().Unix()),
 			NonceStr:  unifiedOrderResp.NonceStr,
 		},

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -38,7 +38,8 @@ type (
 	// WaxPayRet 微信小程序下单返回内容
 	WaxPayRet struct {
 		Ret
-		AppID     string `json:"appid,omitempty"`   // 应用ID
+
+		AppID    string `json:"appId,omitempty"`
 		Package  string `json:"package,omitempty"`  // 扩展字段 统一下单接口返回的 prepay_id 参数值，提交格式如：prepay_id=*
 		SignType string `json:"signType,omitempty"` // 签名算法，暂支持 MD5
 		PaySign  string `json:"paySign,omitempty"`  // 签名
@@ -151,7 +152,7 @@ func (m *WePay) WaxPay(totalFee int, openID string) (results *WaxPayRet, outTrad
 			Timestamp: fmt.Sprintf("%d", time.Now().Unix()),
 			NonceStr:  unifiedOrderResp.NonceStr,
 		},
-		AppID:    m.AppID,
+		AppID: m.AppID,
 		Package:  "prepay_id=" + unifiedOrderResp.PrepayID,
 		SignType: "MD5",
 	}

--- a/pay/pay.go
+++ b/pay/pay.go
@@ -20,8 +20,8 @@ type (
 
 	// Ret 返回的基本内容
 	Ret struct {
-		Timestamp string `json:"timestamp,omitempty"` // 时间戳
-		NonceStr  string `json:"noncestr,omitempty"`  // 随机字符串
+		Timestamp string `json:"timeStamp,omitempty"` // 时间戳
+		NonceStr  string `json:"nonceStr,omitempty"`  // 随机字符串
 	}
 
 	// AppPayRet 下单返回内容
@@ -38,7 +38,7 @@ type (
 	// WaxPayRet 微信小程序下单返回内容
 	WaxPayRet struct {
 		Ret
-
+		AppID     string `json:"appid,omitempty"`   // 应用ID
 		Package  string `json:"package,omitempty"`  // 扩展字段 统一下单接口返回的 prepay_id 参数值，提交格式如：prepay_id=*
 		SignType string `json:"signType,omitempty"` // 签名算法，暂支持 MD5
 		PaySign  string `json:"paySign,omitempty"`  // 签名
@@ -151,6 +151,7 @@ func (m *WePay) WaxPay(totalFee int, openID string) (results *WaxPayRet, outTrad
 			Timestamp: fmt.Sprintf("%d", time.Now().Unix()),
 			NonceStr:  unifiedOrderResp.NonceStr,
 		},
+		AppID:    m.AppID,
 		Package:  "prepay_id=" + unifiedOrderResp.PrepayID,
 		SignType: "MD5",
 	}


### PR DESCRIPTION
之前的微信小程序支付模块是无法使用的，根据文档做了修正，并实际支付测试通过，Ret这块不确定是否和app的参数上有差异，所以另起命名了，小程序的根据文档是采用了驼峰命名的